### PR TITLE
Pass through any existing data found on heading nodes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import { VFileWithOutput } from "unified";
 export interface Heading {
   depth: number;
   value: string;
-  id?: string;
+  data?: any;
 }
 
 export const hasHeadingsData = (
@@ -27,11 +27,12 @@ export const headings = (root: Node) => {
       value: toString(node, { includeImageAlt: false }),
     };
 
-    // If a previous plugin attached the heading id to the node,
-    // store it as part of the heading list.
-    const id = (node?.data as any)?.id;
-    if (id) {
-      heading.id = id;
+    // Other remark plugins can store arbitrary data
+    // inside a node's `data` property, such as a
+    // custom heading id.
+    const data = node?.data;
+    if (data) {
+      heading.data = data;
     }
 
     headingList.push(heading);

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ import { VFileWithOutput } from "unified";
 export interface Heading {
   depth: number;
   value: string;
+  id?: string;
 }
 
 export const hasHeadingsData = (
@@ -21,10 +22,19 @@ export const headings = (root: Node) => {
   const headingList: Heading[] = [];
 
   visit(root, "heading", (node: AstHeading) => {
-    headingList.push({
+    const heading: Heading = {
       depth: node.depth,
       value: toString(node, { includeImageAlt: false }),
-    });
+    };
+
+    // If a previous plugin attached the heading id to the node,
+    // store it as part of the heading list.
+    const id = (node?.data as any)?.id;
+    if (id) {
+      heading.id = id;
+    }
+
+    headingList.push(heading);
   });
 
   return headingList;


### PR DESCRIPTION
Hey, thanks for writing this plugin! I just wanted to submit a patch that fixes an issue I was experiencing (similar to https://github.com/vcarl/remark-headings/issues/1). Let me know if there's anything I'm missing.

The remark plugin [remark-heading-id](https://github.com/imcuttle/remark-heading-id) allows the markdown to specify a custom id for their headings, which results in `data.id` and `data.hProperties.id` being available on the node.

In https://github.com/vcarl/remark-headings/issues/1,  it was suggested to generate anchor tags with a library like `slugger`, but this would ignore the custom id provided inside the markdown content.

This PR adds functionality to detect `id` on the heading node's data object and expose it as part of the headings list. `id` is omitted on a `Heading` if it does not exist in the node's data object.